### PR TITLE
Build rules page

### DIFF
--- a/src/content/single-pages/rules.md
+++ b/src/content/single-pages/rules.md
@@ -2,7 +2,6 @@
 title: Game Jam rules
 slug: rules
 ---
-# Rules
 
 ## Registration and teams
 

--- a/src/routes/game-jam/rules/+page.svelte
+++ b/src/routes/game-jam/rules/+page.svelte
@@ -1,9 +1,62 @@
 <script>
-    import Rules from '../../../content/single-pages/rules.md';
-  </script>
+	import Rules from '../../../content/single-pages/rules.md';
+</script>
 
 <!-- import { metadata as rulesMetadata } from '$content/single-pages/rules.md'; -->
 
-<h1>Rules</h1>
+<main class="page-container">
+	<section class="template-wrapper">
+    <div class="content">
+      <h1>Rules</h1>
+			<Rules />
+		</div>
+	</section>
+</main>
 
-<Rules />
+<style>
+	:global(h1) {
+		font-size: 3rem;
+		color: black;
+    margin-block-start: var(--space-md);
+    margin-block-end: var(--space-xxxxl);
+	}
+
+  :global(h1:not(:first-child)) {
+    margin-block-start: 10rem;
+	}
+
+	:global(h2) {
+		font-family: 'Jura Variable', Arial, Helvetica, sans-serif;
+    margin-bottom: 0.5rem;
+	}
+	:global(p) {
+		font-family: 'Roboto', Arial, Helvetica, sans-serif;
+	}
+
+  :global(li:not(:first-child) p) {
+    margin: 0;
+    margin-top: 0.5rem;
+  }
+
+  :global(li:first-child p){
+    margin-bottom: 0.5rem;
+  }
+
+  :global(.content h2:not(:first-child)){
+    margin-top: var(--space-xxxxl);
+  }
+
+  :global(p:has(+ ul)){
+    margin-top: 2.4rem;
+    margin-bottom: 0.5rem;
+  }
+
+	.template-wrapper {
+		display: flex;
+    flex-direction: column;
+		justify-content: center;
+		font-family: 'Roboto', Arial, Helvetica, sans-serif;
+		padding-inline: var(--space-xxl);
+	}
+ 
+</style>


### PR DESCRIPTION
- Added stylings to rules page. 
- Used selector CSS wizardry on the p tags which were wrapped in li to reduce their margins. The gaps were too wide. 

# Examples
![image](https://github.com/user-attachments/assets/5952b5ae-9faa-407b-a1f4-2179bc3ce8da)

![image](https://github.com/user-attachments/assets/07f9ead6-f045-47a9-a039-fc61c4a5c42a)
